### PR TITLE
Fixes "global name 'p' is not defined" in get_pfile

### DIFF
--- a/tern.py
+++ b/tern.py
@@ -72,7 +72,7 @@ def get_pfile(view):
   project = None
   for f in files.values():
     if f.project.dir == pdir:
-      project = p
+      project = f.project
       break
   pfile = files[fname] = ProjectFile(fname, view, project or Project(pdir))
   return pfile


### PR DESCRIPTION
Traceback (most recent call last):
  File "./sublime_plugin.py", line 200, in on_selection_modified
  File "./sublime_plugin.py", line 154, in run_timed_function
  File "./sublime_plugin.py", line 199, in <lambda>
  File "./tern.py", line 32, in on_selection_modified
  File "./tern.py", line 75, in get_pfile
NameError: global name 'p' is not defined

This fix actually solved my problems with my RequireJS modules :)
