### PR TITLE
Change check_output to check_call

### DIFF
--- a/tern.py
+++ b/tern.py
@@ -471,7 +471,7 @@ def plugin_loaded():
           "\n\nTo get rid of this dialog, either uninstall tern_for_sublime, or set the tern_command setting.",
           "Yes, install."):
         try:
-          subprocess.check_output(["npm", "install"], cwd=plugin_dir)
+          subprocess.check_call(["npm", "install"], cwd=plugin_dir)
         except subprocess.CalledProcessError as e:
           sublime.error_message("Installation failed. Try doing 'npm install' manually in " + plugin_dir + ". Error message was:\n\n" + e.output)
           return


### PR DESCRIPTION
The Python version in Sublime Text 2.0 doesn't have
subprocess.check_output. It does have check_call which considering the
context appears to have the required semantics for this particular
function.

This fixes an issue where a user would have to manually run `npm install`
in the plugin directory, because `subprocess.check_output` would fail
with an AttributeError.
