### PR TITLE
Adds option to use ST 3 new tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,16 @@ The plugin will load its settings from `Preferences.sublime-settings`,
 and recognized the following settings:
 
 `tern_argument_hints` (boolean, defaults to false)  
-Whether to show argument hints. When enabled, the status bar will list
+Whether to show argument hints (May impact responsiveness on slow machines or big projects).
+
+`tern_argument_hints_type` (status, panel, tooltip, defaults to status)  
+__status__ - When status is enabled, the status bar will list
 the arguments for the function call that the cursor is inside.
-Unfortunately, the status bar is tiny and Sublime Text provides no
-saner way to show these hints. May impact responsiveness on slow
-machines or big projects.
+Unfortunately, the status bar is tiny and Sublime Text 2 provides no saner way to show these hints.  
+__panel__ - When panel is enabled, a new panel window opens and will list
+the arguments for the function call that the cursor is inside.  
+__tooltip__ - (only available on SublimeText build 3070+) When tooltip is enabled, a tooltip opens and will list the arguments for the function call that the cursor is inside, as well as, a clickable URL (if available) to the docs and a snippet of documentation (if available).
+
 
 `tern_command` (list of strings) The command to execute to start a
 Tern server. The default is

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ and recognized the following settings:
 `tern_argument_hints` (boolean, defaults to false)  
 Whether to show argument hints (May impact responsiveness on slow machines or big projects).
 
-`tern_argument_hints_type` (status, panel, tooltip, defaults to status)  
+`tern_argument_hints_type` (status, panel, tooltip, defaults to tooltip when available, otherwise status)  
 __status__ - When status is enabled, the status bar will list
 the arguments for the function call that the cursor is inside.
 Unfortunately, the status bar is tiny and Sublime Text 2 provides no saner way to show these hints.  

--- a/tern.py
+++ b/tern.py
@@ -426,6 +426,8 @@ def render_argument_hints(pfile, view, ftype, argpos):
     view.window().run_command("show_panel", {"panel": "output.tern_arghint"})
   elif arghints_type == "status":
     sublime.status_message(msg)
+  elif arghints_type == "tooltip":
+    view.show_popup(msg)
   pfile.showing_arguments = True
 
 def parse_function_type(data):

--- a/tern.py
+++ b/tern.py
@@ -392,6 +392,8 @@ def show_argument_hints(pfile, view):
 
   data = run_command(view, {"type": "type", "preferFunction": True}, call_start, silent=True)
   parsed = data and parse_function_type(data)
+  parsed['url'] = data.get('url', None)
+  parsed['doc'] = data.get('doc', None)
   pfile.cached_arguments = (call_start, parsed)
   render_argument_hints(pfile, view, parsed, argpos)
 
@@ -427,8 +429,34 @@ def render_argument_hints(pfile, view, ftype, argpos):
   elif arghints_type == "status":
     sublime.status_message(msg)
   elif arghints_type == "tooltip":
-    view.show_popup(msg)
+    view.show_popup(render_tooltip(ftype, msg), max_width=600, on_navigate=go_to_url)
   pfile.showing_arguments = True
+
+def go_to_url(url=None):
+  if url:
+    import webbrowser
+    webbrowser.open(url)
+
+def render_tooltip(ftype, msg):
+  output = '''
+    <style>
+      div {
+        font-size: 14px;
+      }
+      .bold{
+        font-weight: bold
+      }
+    </style>
+  '''
+  output = output + '<div class="bold">{}</div>'.format(msg)
+  url = '<div><a href={url}>{url}</a></div>'
+  doc = '<div>{doc}</div>'
+
+  if ftype['url']:
+    output += url.format(url=ftype['url'])
+  if ftype['doc']:
+    output += doc.format(doc=ftype['doc'])
+  return output
 
 def parse_function_type(data):
   type = data["type"]

--- a/tern.py
+++ b/tern.py
@@ -12,7 +12,7 @@ def is_js_file(view):
 
 files = {}
 arghints_enabled = False
-arghints_type = "status"
+arghints_type = "tooltip"
 tern_command = None
 tern_arguments = []
 tern_arghint = ""
@@ -546,7 +546,9 @@ def plugin_loaded():
   settings = sublime.load_settings("Preferences.sublime-settings")
   arghints_enabled = settings.get("tern_argument_hints", False)
   if arghints_enabled:
-    arghints_type = settings.get("tern_argument_hints_type", "status")
+    arghints_type = settings.get("tern_argument_hints_type", arghints_type)
+  if arghints_type == "tooltip" and not "show_popup" in dir(sublime.View):
+    arghints_type = "status"
   tern_arguments = settings.get("tern_arguments", [])
   tern_command = settings.get("tern_command", None)
   if tern_command is None:


### PR DESCRIPTION
Adds tooltip support for ST 3, if a URL or doc is available, it shows that as well.

As of right now this will only work on the very latest ST 3 dev build (3070)

![screenshot 2015-02-17 11 33 38](https://cloud.githubusercontent.com/assets/141903/6232304/18c92d88-b699-11e4-9180-0d0e48ce36c7.png)

![screenshot 2015-02-17 11 33 58](https://cloud.githubusercontent.com/assets/141903/6232307/1fe659ce-b699-11e4-9036-c38eaf659705.png)