### PR TITLE
autocomplete and function hint in tooltip qol change

### DIFF
--- a/tern.py
+++ b/tern.py
@@ -431,7 +431,7 @@ def render_argument_hints(pfile, view, ftype, argpos):
   elif arghints_type == "status":
     sublime.status_message(msg)
   elif arghints_type == "tooltip":
-    view.show_popup(render_tooltip(ftype, msg), max_width=600, on_navigate=go_to_url)
+    view.show_popup(render_tooltip(ftype, msg), sublime.COOPERATE_WITH_AUTO_COMPLETE, max_width=600, on_navigate=go_to_url)
   pfile.showing_arguments = True
 
 def go_to_url(url=None):


### PR DESCRIPTION
While typing arguments in a function, each letter typed will cause the function hint tool-tip to switch to the autocomplete popup and vice versa. This change will display the autocomplete and the function hints side by side. (source of fix: http://www.sublimetext.com/forum/viewtopic.php?f=2&t=17610)
![ac](https://cloud.githubusercontent.com/assets/814583/6841830/729b8826-d34d-11e4-86a7-4827879ea1ed.png)

