### PR TITLE
Argument completion feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ __panel__ - When panel is enabled, a new panel window opens and will list
 the arguments for the function call that the cursor is inside.  
 __tooltip__ - (only available on SublimeText build 3070+) When tooltip is enabled, a tooltip opens and will list the arguments for the function call that the cursor is inside, as well as, a clickable URL (if available) to the docs and a snippet of documentation (if available).
 
+`tern_argument_completion` (boolean, default to false)  
+Auto complete function arguments (similar to eclipse).  
+e.g. `document.addEv` will show completion for `addEventListener (fn/2)` which completes to
+`document.addEventListener(type, listener)`. The first argument will be selected.
+Use `tab` to select the next argument.
+
+Completions for smaller number arguments are supported.  
+e.g. in the extreme case, `THREE.SphereGeometry` has 7 arguments, most of which are optional. `THREE.SphG`
+will show completions for `SphereGeometry (fn/7)`, `SphereGeometry (fn/6)`, ... , `SphereGeometry (fn/0)`.
+Typing 3 (i.e. `THREE.SphG3`) will select the completion `THREE.SphereGeometry (fn/3)` which completes to `THREE.SphereGeometry(a, b, c)`.
+
 
 `tern_command` (list of strings) The command to execute to start a
 Tern server. The default is


### PR DESCRIPTION
Parse the type of each function for the list of arguments and insert it into the auto completion list.

![b1](https://cloud.githubusercontent.com/assets/814583/6884065/d5a00df0-d58e-11e4-87fb-3b96c488f061.png)
![b2](https://cloud.githubusercontent.com/assets/814583/6884066/de1fbe76-d58e-11e4-81a5-224eba6f793d.png)

Functions with optional arguments are handled by inserting completions with less arguments into the auto completion list. Typing in a number choose the amount of arguments for the completion.
![c1](https://cloud.githubusercontent.com/assets/814583/6884067/e7432376-d58e-11e4-9099-9f81357abdb2.png)
![c2](https://cloud.githubusercontent.com/assets/814583/6884069/eb24b6e4-d58e-11e4-9edc-c0a9200f8773.png)
![c3](https://cloud.githubusercontent.com/assets/814583/6884072/ee4f750c-d58e-11e4-9467-558a3f04f5a9.png)

`tern_argument_completion` is the option to turn it on/off. By default it's false.

