### PR TITLE
Line-separated JsDoc attributes for Sublime

### DIFF
--- a/utils/renderer.py
+++ b/utils/renderer.py
@@ -66,11 +66,15 @@ def get_html_message_from_ftype(ftype, argpos):
     </div>
   '''
 
+  # Line-separate @-attributes
+  doc = ftype['doc']
+  if doc: doc = re.sub(r"(?:\@)(.)", r"<br>@\1", doc)
+
   template_data = {
     'style': style,
     'func_signature': hint_line(func_signature),
     'doc_link': hint_line(link(ftype['url'])),
-    'doc': hint_line(ftype['doc'])
+    'doc': hint_line(doc)
   }
 
   return template.format(**template_data)

--- a/utils/renderer.py
+++ b/utils/renderer.py
@@ -68,7 +68,7 @@ def get_html_message_from_ftype(ftype, argpos):
 
   # Line-separate @-attributes
   doc = ftype['doc']
-  if doc: doc = re.sub(r"(?:\@)(.)", r"<br>@\1", doc)
+  if doc: doc = re.sub(r" @(.)", r"<br>@\1", doc)
 
   template_data = {
     'style': style,


### PR DESCRIPTION
This separates stuff like this:

```
Does something @params {Object} User attributes @return {Number} Something else @author user@example.com
```

to this
```
Does something
@params {Object} User attributes
@return {Number} Something else
@author user@example.com
```

on the tooltip hint - which makes it much easier to read.