### PR TITLE
Line-break to HTML br jsdoc

### DIFF
--- a/utils/renderer.py
+++ b/utils/renderer.py
@@ -66,11 +66,14 @@ def get_html_message_from_ftype(ftype, argpos):
     </div>
   '''
 
+  doc = ftype['doc']
+  if doc: doc = doc.replace("\n", "<br>")
+
   template_data = {
     'style': style,
     'func_signature': hint_line(func_signature),
     'doc_link': hint_line(link(ftype['url'])),
-    'doc': hint_line(ftype['doc'])
+    'doc': hint_line(doc)
   }
 
   return template.format(**template_data)


### PR DESCRIPTION
In preparation of the patch coming for the doc_comment plugin for tern we replace newlines with <br> in tern_for_sublime so that line-breaks gets rendered properly when using the tooltip hints.