### PR TITLE
Adds command to show arg hints

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -22,5 +22,9 @@
   {
     "caption": "tern_for_sublime: Disable Project",
     "command": "tern_disable_project"
+  },
+  {
+    "caption": "tern_for_sublime: Show Argument Hints",
+    "command": "tern_show_arg_hints"
   }
 ]

--- a/tern.py
+++ b/tern.py
@@ -624,6 +624,15 @@ class TernEnableProject(sublime_plugin.TextCommand):
     pfile = get_pfile(self.view)
     pfile.project.disabled = True
 
+class TernShowArgHints(sublime_plugin.WindowCommand):
+  def run(self, **args):
+    view = self.window.active_view()
+    if not view:
+      return
+    pfile = get_pfile(view)
+    if pfile is not None:
+      show_argument_hints(pfile, view)
+
 # fetch a certain setting from the package settings file and if it doesn't exist check the
 # Preferences.sublime-settings file for backwards compatibility.
 def get_setting(key, default):


### PR DESCRIPTION
That's it.

Nice if `"tern_argument_hints": false,`, but you still want to be able to show arg hints on command.

Just look for __tern_for_sublime: Show Argument Hints__ in the command palette.